### PR TITLE
Add OSX support, fixes #1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,28 @@
-
 ASSETS_ZIP = Asset-Package_04282023.ca9655a386a46bda0b6238cca2651e8f27fcb5c9.zip
-INSCAPE_DIR = $(HOME)/.config/inkscape
+UNAME:=$(shell uname)
+ifeq ($(UNAME), Darwin)
+	INKSCAPE_DIR := $(HOME)/Library/Application\ Support/org.inkscape.Inkscape/config/inkscape
+else
+	INKSCAPE_DIR := $(HOME)/.config/inkscape
+endif
 
 all: clean build-symbols install-templates install-symbols
 clean: clean-templates clean-symbols
 
 clean-templates:
-	rm -Rfv $(INSCAPE_DIR)/templates/aws-architect
+	rm -Rfv $(INKSCAPE_DIR)/templates/aws-architect
 
 clean-symbols:
-	rm -Rfv $(INSCAPE_DIR)/symbols/aws-architect
+	rm -Rfv $(INKSCAPE_DIR)/symbols/aws-architect
 
 clean-awslab-repo-cache:
 	rm -Rfv ./aws-inkscape-symbols/awslabs-repo
 
 install-symbols:
-	rsync -av ./aws-inkscape-symbols/target/ $(INSCAPE_DIR)/symbols/aws-architect/
+	rsync -av ./aws-inkscape-symbols/target/ $(INKSCAPE_DIR)/symbols/aws-architect/
 
 install-templates:
-	rsync -av templates/ $(INSCAPE_DIR)/templates/aws-architect/
+	rsync -av templates/ $(INKSCAPE_DIR)/templates/aws-architect/
 
 build-symbols:
 	cd ./aws-inkscape-symbols; ./build.sh $(ASSETS_ZIP)

--- a/aws-inkscape-symbols/build.sh
+++ b/aws-inkscape-symbols/build.sh
@@ -50,7 +50,7 @@ for dir in build/Resource*/*; do
     #darkfiles=$dir/Res_48_Dark/*.svg
   fi
 
-  python files_to_svg.py "Resource $componentname" target/AWS-Resource-$componentname-light.svg $lightfiles
+  python3 files_to_svg.py "Resource $componentname" target/AWS-Resource-$componentname-light.svg $lightfiles
   #python files_to_svg.py "Resource $componentname-dark" target/aws-$componentname-resource-dark.svg $darkfiles
 done
 
@@ -58,20 +58,20 @@ for dir in build/Architecture-Service*/*; do
   componentname=$(basename $dir | sed 's/^Arch_//' | tr 'A-Z_' 'a-z-')
   echo $dir
   files=$dir/*48/*.svg
-  python files_to_svg.py "Service $componentname" target/AWS-Service-$componentname.svg $files
+  python3 files_to_svg.py "Service $componentname" target/AWS-Service-$componentname.svg $files
 done
 
 for dir in build/Category*/Arch-Category_48; do
   echo $dir
   componentname=$(basename $dir | sed 's/^Arch_//' | tr 'A-Z_' 'a-z-')
   files=$dir/*.svg
-  python files_to_svg.py "Category $componentname" target/AWS-Category-$componentname.svg $files
+  python3 files_to_svg.py "Category $componentname" target/AWS-Category-$componentname.svg $files
 done
 
 for dir in build/Groups/*; do
   echo $dir
   componentname=$(basename $dir | sed 's/^Arch_//' | tr 'A-Z_' 'a-z-')
   files=$dir/*.svg
-  python files_to_svg.py "Group $componentname" target/AWS-Group-$componentname.svg $files
+  python3 files_to_svg.py "Group $componentname" target/AWS-Group-$componentname.svg $files
 done
 


### PR DESCRIPTION
- Fixes typo in INKSCAPE_DIR name
- makes INKSCAPE_DIR location conditional on uname. This will not work on windows; if uname is unavailable that's as good a windows check as any.
- switches from python to python3. python3 always has that symlink, on Linux too, but in Homebrew the python symlink may not be in your path see https://docs.brew.sh/Homebrew-and-Python - it's in libexec

Handling of spaces in paths isn't great, because it's a Makefile. The space in "Application Support" is escaped but spaces in $HOME are not. This isn't really fixable in Make, and the windows install is going to be awkward with both Make and bash needed; might be that going python-only is the answer.